### PR TITLE
Project version fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Patrick Forringer <patrick@forringer.com>", "Jeremy Satterfield <jsa
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "3.7"
+python = "3.7.*"
 django = "=2.1.1"
 pycatalog = "=1.2.0"
 jinja2 = "=2.10"


### PR DESCRIPTION
The default python image for 3.7 automatically imports new patch versions, so pyproject.toml needed to accept those as well as the base 3.7.

Blocked by #41 